### PR TITLE
Added unit tests, sliders for applicable clamped variables, and Optional Odin Inspector integration

### DIFF
--- a/Assets/SO Architecture/AssemblyInfo.cs
+++ b/Assets/SO Architecture/AssemblyInfo.cs
@@ -2,3 +2,4 @@
 
 // Expose internal members to editor assembly for inspectors, other editor windows or functions
 [assembly: InternalsVisibleTo("ScriptableObject-Architecture.Editor")]
+[assembly: InternalsVisibleTo("ScriptableObject-Architecture.Tests")]

--- a/Assets/SO Architecture/Editor/ClampValueHelper.cs
+++ b/Assets/SO Architecture/Editor/ClampValueHelper.cs
@@ -2,6 +2,11 @@
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEditor;
+using UnityEngine;
+
+#if ODIN_INSPECTOR
+using Sirenix.Utilities.Editor;
+#endif
 
 namespace ScriptableObjectArchitecture.Editor
 {
@@ -45,11 +50,27 @@ namespace ScriptableObjectArchitecture.Editor
 
             if (SUPPORTED_INT_TYPES.Contains(valueType))
             {
+                #if ODIN_INSPECTOR
+                valueProp.intValue = SirenixEditorFields.RangeIntField(
+                    new GUIContent(valueProp.displayName),
+                    valueProp.intValue,
+                    minProp.intValue,
+                    maxProp.intValue);
+                #else
                 EditorGUILayout.IntSlider(valueProp, minProp.intValue, maxProp.intValue);
+                #endif
             }
             else if (SUPPORTED_FLOAT_TYPES.Contains(valueType))
             {
+                #if ODIN_INSPECTOR
+                valueProp.floatValue = SirenixEditorFields.RangeFloatField(
+                    new GUIContent(valueProp.displayName),
+                    valueProp.floatValue,
+                    minProp.floatValue,
+                    maxProp.floatValue);
+                #else
                 EditorGUILayout.Slider(valueProp, minProp.floatValue, maxProp.floatValue);
+                #endif
             }
         }
 

--- a/Assets/SO Architecture/Editor/ClampValueHelper.cs
+++ b/Assets/SO Architecture/Editor/ClampValueHelper.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEditor;
+
+namespace ScriptableObjectArchitecture.Editor
+{
+    /// <summary>
+    /// A helper class for drawing better controls for clamped value types (mostly simple C# types)
+    /// </summary>
+    public static class ClampValueHelper
+    {
+        private static readonly List<Type> SUPPORTED_INT_TYPES;
+        private static readonly List<Type> SUPPORTED_FLOAT_TYPES;
+
+        static ClampValueHelper()
+        {
+            SUPPORTED_INT_TYPES = new List<Type>
+            {
+                typeof(sbyte),
+                typeof(byte),
+                typeof(short),
+                typeof(ushort),
+                typeof(int)
+            };
+
+            SUPPORTED_FLOAT_TYPES = new List<Type>
+            {
+                typeof(float)
+            };
+        }
+
+        /// <summary>
+        ///  Draws a slider for the passed <see cref="SerializedProperty"/> values.
+        /// </summary>
+        /// <param name="valueProp"></param>
+        /// <param name="minProp"></param>
+        /// <param name="maxProp"></param>
+        public static void DrawClampRangeLayout(
+            SerializedProperty valueProp,
+            SerializedProperty minProp,
+            SerializedProperty maxProp)
+        {
+            var valueType = GetType(valueProp);
+
+            if (SUPPORTED_INT_TYPES.Contains(valueType))
+            {
+                EditorGUILayout.IntSlider(valueProp, minProp.intValue, maxProp.intValue);
+            }
+            else if (SUPPORTED_FLOAT_TYPES.Contains(valueType))
+            {
+                EditorGUILayout.Slider(valueProp, minProp.floatValue, maxProp.floatValue);
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the passed <paramref name="valueProp"/> can be drawn with better clamp controls.
+        /// </summary>
+        /// <param name="valueProp"></param>
+        /// <returns></returns>
+        public static bool CanDrawClampRange(SerializedProperty valueProp)
+        {
+            var valueType = GetType(valueProp);
+
+            return CanDrawClampRange(valueType);
+        }
+
+        /// <summary>
+        /// Returns true if the passed <paramref name="valueType"/> can be drawn with better clamp controls.
+        /// </summary>
+        /// <param name="valueType"></param>
+        /// <returns></returns>
+        public static bool CanDrawClampRange(Type valueType)
+        {
+            return valueType != null &&
+                   SUPPORTED_INT_TYPES.Contains(valueType) ||
+                   SUPPORTED_FLOAT_TYPES.Contains(valueType);
+        }
+
+        /// <summary>
+        /// Attempts to get the true type of the <see cref="SerializedProperty"/> on its object. This purposefully doesn't care about
+        /// attempting to resolve <see cref="SerializedProperty"/> of array or value types as its usage in this class
+        /// should always be constrained to a single value type and if it doesn't its not relevant for this class.
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns></returns>
+        private static Type GetType(SerializedProperty property)
+        {
+            var containingObjectType = property.serializedObject.targetObject.GetType();
+            var fi = containingObjectType.GetField(property.propertyPath, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            return fi == null ? null : fi.FieldType;
+        }
+    }
+}

--- a/Assets/SO Architecture/Editor/ClampValueHelper.cs.meta
+++ b/Assets/SO Architecture/Editor/ClampValueHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8ada6fe063b54c4ebae03572498648c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SO Architecture/Editor/Drawers/SceneInfoPropertyDrawer.cs
+++ b/Assets/SO Architecture/Editor/Drawers/SceneInfoPropertyDrawer.cs
@@ -1,6 +1,10 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
+#if ODIN_INSPECTOR
+using Sirenix.Utilities.Editor;
+#endif
+
 namespace ScriptableObjectArchitecture.Editor
 {
     [CustomPropertyDrawer(typeof(SceneInfo))]
@@ -29,7 +33,13 @@ namespace ScriptableObjectArchitecture.Editor
             };
 
             var oldSceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(sceneNameProperty.stringValue);
+
+            #if ODIN_INSPECTOR
+            var sceneAsset = SirenixEditorFields.UnityObjectField(sceneAssetRect, oldSceneAsset, typeof(SceneAsset), false);
+            #else
             var sceneAsset = EditorGUI.ObjectField(sceneAssetRect, oldSceneAsset, typeof(SceneAsset), false);
+            #endif
+
             var sceneAssetPath = AssetDatabase.GetAssetPath(sceneAsset);
             if (sceneNameProperty.stringValue != sceneAssetPath)
             {

--- a/Assets/SO Architecture/Editor/Generic Property Drawer/PropertyIterator.cs
+++ b/Assets/SO Architecture/Editor/Generic Property Drawer/PropertyIterator.cs
@@ -19,8 +19,12 @@ namespace ScriptableObjectArchitecture.Editor
         protected readonly SerializedProperty iterator;
         protected readonly SerializedProperty endProperty;
 
+        #pragma warning disable 0414
+
         private bool consumeChildren;
         private int parentDepth;
+
+        #pragma warning restore 0414
 
         public virtual bool Next()
         {

--- a/Assets/SO Architecture/Variables/BaseVariable.cs
+++ b/Assets/SO Architecture/Variables/BaseVariable.cs
@@ -5,9 +5,9 @@ namespace ScriptableObjectArchitecture
 {
     public abstract class BaseVariable : GameEventBase
     {
-        public abstract bool IsClamped { get; }
+        public abstract bool IsClamped { get; internal set; }
         public abstract bool Clampable { get; }
-        public abstract bool ReadOnly { get; }
+        public abstract bool ReadOnly { get; internal set; }
         public abstract System.Type Type { get; }
         public abstract object BaseValue { get; set; }
     }
@@ -38,6 +38,7 @@ namespace ScriptableObjectArchitecture
                     return default(T);
                 }
             }
+            internal set { _minClampedValue = value; }
         }
         public virtual T MaxClampValue
         {
@@ -52,11 +53,23 @@ namespace ScriptableObjectArchitecture
                     return default(T);
                 }
             }
+            internal set { _maxClampedValue = value; }
         }
 
         public override bool Clampable { get { return false; } }
-        public override bool ReadOnly { get { return _readOnly; } }
-        public override bool IsClamped { get { return _isClamped; } }
+
+        public override bool ReadOnly
+        {
+            get { return _readOnly; }
+            internal set { _readOnly = value; }
+        }
+
+        public override bool IsClamped
+        {
+            get { return _isClamped; }
+            internal set { _isClamped = value; }
+        }
+
         public override System.Type Type { get { return typeof(T); } }
         public override object BaseValue
         {
@@ -132,7 +145,7 @@ namespace ScriptableObjectArchitecture
             T oldValue = _value;
             T newValue = base.SetValue(value);
 
-            if (!newValue.Equals(oldValue))
+            if (!newValue.Equals(oldValue) && _event != null)
                 _event.Invoke(newValue);
 
             return newValue;

--- a/Assets/Unit Tests.meta
+++ b/Assets/Unit Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e311b481fb12c17499de272b18e59c82
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Unit Tests/ScriptableObject-Architecture.Tests.asmdef
+++ b/Assets/Unit Tests/ScriptableObject-Architecture.Tests.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "ScriptableObject-Architecture.Tests",
+    "references": [
+        "GUID:63ebd60d5c68886498ecfee04b5d6a12"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Unit Tests/ScriptableObject-Architecture.Tests.asmdef.meta
+++ b/Assets/Unit Tests/ScriptableObject-Architecture.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ea8fedd05b208534daa26e0830f8e076
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Unit Tests/Variables.meta
+++ b/Assets/Unit Tests/Variables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 795736db9b23d6249830c536bc732a5b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Unit Tests/Variables/ClampVariables.cs
+++ b/Assets/Unit Tests/Variables/ClampVariables.cs
@@ -1,0 +1,280 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+// ReSharper disable CheckNamespace
+
+namespace ScriptableObjectArchitecture.Tests
+{
+    [TestFixture]
+    internal sealed class ClampVariables
+    {
+        [Test]
+        public void AssertThatFloatVariablesClampValues()
+        {
+            const float MIN = 0f;
+            const float MAX = 5f;
+
+            var variable = ScriptableObject.CreateInstance<FloatVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 1f;
+
+            Assert.AreEqual(1f, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 10f;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = -10f;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatDoubleVariablesClampValues()
+        {
+            const double MIN = 0d;
+            const double MAX = 5d;
+
+            var variable = ScriptableObject.CreateInstance<DoubleVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 1d;
+
+            Assert.AreEqual(1d, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 10d;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = -10d;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatIntVariablesClampValues()
+        {
+            const int MIN = 0;
+            const int MAX = 5;
+
+            var variable = ScriptableObject.CreateInstance<IntVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 1;
+
+            Assert.AreEqual(1, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 10;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = -10;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatLongVariablesClampValues()
+        {
+            const long MIN = 0;
+            const long MAX = 5;
+
+            var variable = ScriptableObject.CreateInstance<LongVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 1;
+
+            Assert.AreEqual(1, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 10;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = -10;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatShortVariablesClampValues()
+        {
+            const short MIN = 0;
+            const short MAX = 5;
+
+            var variable = ScriptableObject.CreateInstance<ShortVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 1;
+
+            Assert.AreEqual(1, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 10;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = -10;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatUintVariablesClampValues()
+        {
+            const uint MIN = 5;
+            const uint MAX = 10;
+
+            var variable = ScriptableObject.CreateInstance<UIntVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 6;
+
+            Assert.AreEqual(6, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 15;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = 0;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatULongVariablesClampValues()
+        {
+            const ulong MIN = 5;
+            const ulong MAX = 10;
+
+            var variable = ScriptableObject.CreateInstance<ULongVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 6;
+
+            Assert.AreEqual(6, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 15;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = 0;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatUShortVariablesClampValues()
+        {
+            const ushort MIN = 5;
+            const ushort MAX = 10;
+
+            var variable = ScriptableObject.CreateInstance<UShortVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 6;
+
+            Assert.AreEqual(6, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 15;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = 0;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatByteVariablesClampValues()
+        {
+            const byte MIN = 5;
+            const byte MAX = 10;
+
+            var variable = ScriptableObject.CreateInstance<ByteVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 6;
+
+            Assert.AreEqual(6, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 15;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = 0;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+
+        [Test]
+        public void AssertThatSByteVariablesClampValues()
+        {
+            const sbyte MIN = 5;
+            const sbyte MAX = 10;
+
+            var variable = ScriptableObject.CreateInstance<SByteVariable>();
+            variable.IsClamped = true;
+            variable.MinClampValue = MIN;
+            variable.MaxClampValue = MAX;
+
+            // Value can be set within range
+            variable.Value = 6;
+
+            Assert.AreEqual(6, variable.Value);
+
+            // Value wll be clamped past greater extents of range
+            variable.Value = 15;
+
+            Assert.AreEqual(MAX, variable.Value);
+
+            // Value wll be clamped past lower extents of range
+            variable.Value = 0;
+
+            Assert.AreEqual(MIN, variable.Value);
+        }
+    }
+}

--- a/Assets/Unit Tests/Variables/ClampVariables.cs.meta
+++ b/Assets/Unit Tests/Variables/ClampVariables.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3535356ff4fd4e74c88f4f0fe392e5ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Unit Tests/Variables/ReadOnlyVariables.cs
+++ b/Assets/Unit Tests/Variables/ReadOnlyVariables.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace ScriptableObjectArchitecture.Tests
+{
+    [TestFixture]
+    internal sealed class ReadOnlyVariables
+    {
+        [Test]
+        public void AssertThatReadOnlyVariableCannotBeModified()
+        {
+            var variable = ScriptableObject.CreateInstance<FloatVariable>();
+            variable.Value = 5f;
+            variable.ReadOnly = true;
+
+            variable.Value = 10f;
+
+            Assert.AreEqual(5, variable.Value);
+        }
+    }
+}

--- a/Assets/Unit Tests/Variables/ReadOnlyVariables.cs.meta
+++ b/Assets/Unit Tests/Variables/ReadOnlyVariables.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5676ec28427ed244ba191319703a9bf4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableObject-Architecture-Tests.csproj.DotSettings
+++ b/ScriptableObject-Architecture-Tests.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cso_0020architecture_0020unit_0020tests_005Cvariables/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
## Summary

For reviewing, you can ignore the last commit (PR content only) and look at only the three first ones for content.

This PR adds several things:
* I've modified BaseVariable and BaseVariable<T> so they can be internally unit-tested by exposing several read-only fields as internal and adding unit tests for all clampable types to ensure they are working as well as a unit test to verify read-only variables work as expected (cannot be modified at runtime in code)
* I've modified the inspector code so that for certain numeric types (anything with precision equal to or less than Int32 (int) and Float (float)) a slider can be drawn in the inspector for modifying that value rather than an int field. This specifically does not support numeric types with greater precision or length than those previously mentioned types as Unity does not support drawing sliders for those types explicitly and if used with int/float sliders would cause loss of precision.

**Has Slider Support**
![image](https://user-images.githubusercontent.com/40764984/78423840-754f5b00-7669-11ea-9d69-77543de73991.png)

**Does NOT have Slider Support**
![image](https://user-images.githubusercontent.com/40764984/78423850-88fac180-7669-11ea-99c4-a2cda035229a.png)

## Testing

Run unit tests; all should pass without error (warnings in console are expected).

Check out the example content I've created for many of the variable types and for any of the clamped types ensure that for any numeric values with precision, length equal to or less than Int32 or Float that a slider is drawn when Clamped is set to true.

Odin Inspector is imported temporarily so that it's optional integration can be verified. There should not be any compiler errors when present and if deleted(deleting the commit Odin was added in should be done for this step to remove both the content and the added Scripting Symbol) should not have any compiler errors.