### PR TITLE
Fix equality check

### DIFF
--- a/Assets/SO Architecture/Variables/BaseVariable.cs
+++ b/Assets/SO Architecture/Variables/BaseVariable.cs
@@ -163,10 +163,14 @@ namespace ScriptableObjectArchitecture
 
             T newValue = _value;
 
-            if (!newValue.Equals(oldValue) && _event != null)
+            if (!EqualityComparer<T>.Default.Equals(oldValue, newValue))
             {
                 result = true;
-                _event.Invoke(newValue);
+
+                if (_event != null)
+                {
+                    _event.Invoke(newValue);
+                }
             }
 
             return result;

--- a/Assets/SO Architecture/package.json
+++ b/Assets/SO Architecture/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.danieleverland.scriptableobjectarchitecture",
     "displayName": "ScriptableObject-Architecture",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "unity": "2019.2",
     "description": "Makes using Scriptable Objects as a fundamental part of your architecture in Unity super easy",
     "keywords":

--- a/Assets/Unit Tests/Variables/ReferenceTypeVariables.cs
+++ b/Assets/Unit Tests/Variables/ReferenceTypeVariables.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace ScriptableObjectArchitecture.Tests
+{
+    [TestFixture]
+    internal sealed class ReferenceTypeVariables
+    {
+        private sealed class Foo { }
+
+        private sealed class MockRefVariable : BaseVariable<Foo> { }
+        private sealed class MockRefVariableWithEvent : BaseVariable<Foo, UnityEvent<Foo>> { }
+
+        /// <summary>
+        /// Ensure ref-type variables can be set to null without causing errors.
+        /// </summary>
+        [Test]
+        public void CanSetReferenceTypeVariableValueToNull()
+        {
+            var foo = new Foo();
+            var refVariable = (MockRefVariable)ScriptableObject.CreateInstance(typeof(MockRefVariable));
+            refVariable.Value = foo;
+
+            Assert.AreEqual(foo, refVariable.Value);
+
+            refVariable.Value = null;
+
+            Assert.IsNull(refVariable.Value);
+        }
+
+        /// <summary>
+        /// Ensure ref-type variables with events can be set to null without causing errors.
+        /// </summary>
+        [Test]
+        public void CanSetReferenceTypeVariableWithEventValueToNull()
+        {
+            var foo = new Foo();
+            var refVariable = (MockRefVariableWithEvent)ScriptableObject.CreateInstance(typeof(MockRefVariableWithEvent));
+            refVariable.Value = foo;
+
+            Assert.AreEqual(foo, refVariable.Value);
+
+            refVariable.Value = null;
+
+            Assert.IsNull(refVariable.Value);
+        }
+    }
+}

--- a/Assets/Unit Tests/Variables/ReferenceTypeVariables.cs.meta
+++ b/Assets/Unit Tests/Variables/ReferenceTypeVariables.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3cb141938eecfb84f99d18a3b6c6da99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR fixes a bug with BaseVariableWithEvent<T, TEvent> where the equality check was done in a way that would cause an NRE if the value set was a null reference type. This has been changed to use the EqualityComparer which is currently in use for BaseVariable<T>.

I've also added a set of unit tests to help verify this in the future.

To test this PR run all unit tests; everything should pass.